### PR TITLE
TILファイルの追加 - 2026/07/27エントリ

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -44,6 +44,11 @@ export default defineConfig({
             },
             sidebar: [
                 {
+                    label: 'TIL (Today I Learned)',
+                    link: '/til/',
+                    badge: { text: '学習記録', variant: 'note' },
+                },
+                {
                     label: 'API設計ガイド拡張',
                     collapsed: true,
                     autogenerate: { directory: 'API設計ガイド拡張' },

--- a/src/content/docs/TIL.mdx
+++ b/src/content/docs/TIL.mdx
@@ -1,0 +1,12 @@
+---
+title: TIL (Today I Learned)
+description: 日々学んだことの記録
+---
+
+# TIL (Today I Learned)
+
+日々の学習記録をまとめています。
+
+## 2026/07/27
+
+- aws・starlightDemo


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

シンプルなTIL (Today I Learned) ファイルを作成し、2026年7月27日のエントリを追加しました。

## 変更内容

- `src/content/docs/TIL.mdx` を作成（単一ファイル形式）
- `astro.config.mjs` のサイドバーにTILへのリンクを追加
- 2026/07/27のエントリとして「aws・starlightDemo」を記録

## ファイル構造

単一のTIL.mdxファイルに日付ごとのエントリを追記していく形式です。

## 確認方法

1. サイドバーの「TIL (Today I Learned)」リンクをクリック
2. 2026/07/27のエントリが表示されることを確認
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://w1743470515-jqo823312.slack.com/archives/C0BKSNZQXNH/p1785109325324899?thread_ts=1785109325.324899&cid=C0BKSNZQXNH)

<div><a href="https://cursor.com/agents/bc-12ef90b9-8269-580b-b1a4-1c472e627eb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12ef90b9-8269-580b-b1a4-1c472e627eb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

